### PR TITLE
Regression test: update SConstruct to use os.environ as starting

### DIFF
--- a/tests/SConstruct
+++ b/tests/SConstruct
@@ -1,3 +1,5 @@
-env = Environment(CXXFLAGS = ['-std=c++17'])
+import os
+
+env = Environment(ENV = os.environ, CXXFLAGS = ['-std=c++17'])
 
 env.Program('c++_to_python.cpp')


### PR DESCRIPTION
environment so that it finds the user-preferred compiler version.